### PR TITLE
Use layerX / layerY instead of clientX / clientY in #bindUi()

### DIFF
--- a/js/jumperbot.js
+++ b/js/jumperbot.js
@@ -346,8 +346,8 @@ var JumperBot = function () {
          */
         bindUI: function () {
 
-            canvas.onclick = function ( ev ) {
-                fireBullet( ev.clientX, ev.clientY );
+            canvas.onclick = function ( event ) {
+                fireBullet( event.layerX, event.layerY );
             }
 
         }


### PR DESCRIPTION
Centered the `<canvas>` and suddenly my clicks where off because of the X/Y positions from `clientX` and `clientY`.

After this PR is accepted I'll send another centering the `<canvas>`.
